### PR TITLE
[RW-600] Generate Python cells for materializing cohorts from concept search results.

### DIFF
--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -92,7 +92,8 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   
   function generate_python_code() {
     var kernel = IPython.notebook.kernel;
-    cell_text = 'id = ' + selected_row_id;
+    cell_text = 'from nbformat import v4 as nbf\n'
+    cell_text += 'nbf.new_code_cell("print \\'foo\\'")'
     command = 'get_ipython().set_next_input("' + cell_text + '")';
     alert(command);
     kernel.execute(command);

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -167,7 +167,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 """
 
 _CONCEPT_ROW_HTML_TEMPLATE = """
-  <tr id="row_{id}" onclick='select_concept("{id}", {js_escaped_domain})'>
+  <tr id="row_{id}" onclick='select_concept("{id}", {js_escaped_name}, {js_escaped_domain}, {js_escaped_vocabulary}, {standard})'>
     <td>{id}</td>
     <td style="text-align: left">{name}</td>
     <td style="text-align: left">{code}</td>
@@ -201,11 +201,14 @@ def display_concepts(request):
     for concept in concepts:
       row_html += _CONCEPT_ROW_HTML_TEMPLATE.format(id=concept.concept_id,
                                                     name=html.escape(concept.concept_name),
+                                                    js_escaped_name=json.dumps(concept.concept_name),
                                                     code=html.escape(concept.concept_code),
                                                     domain=html.escape(concept.domain_id),
                                                     js_escaped_domain=json.dumps(concept.domain_id),
                                                     vocabulary=html.escape(concept.vocabulary_id),
-                                                    count=concept.count_value)
+                                                    js_escaped_vocabulary=json.dumps(concept.vocabulary_id),
+                                                    count=concept.count_value,
+                                                    standard=concept.standard_concept)
     table_html = _CONCEPT_TABLE_HTML_TEMPLATE % row_html
     display(HTML(table_html))
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -208,7 +208,7 @@ def display_concepts(request):
                                                     vocabulary=html.escape(concept.vocabulary_id),
                                                     js_escaped_vocabulary=json.dumps(concept.vocabulary_id),
                                                     count=concept.count_value,
-                                                    standard=concept.standard_concept)
+                                                    standard='true' if concept.standard_concept else 'false')
     table_html = _CONCEPT_TABLE_HTML_TEMPLATE % row_html
     display(HTML(table_html))
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -1,3 +1,8 @@
+import json
+
+import html
+import pandas as pd
+from IPython.display import display, HTML
 from aou_workbench_client.auth import get_authenticated_swagger_client
 from aou_workbench_client.config import all_of_us_config
 from aou_workbench_client.swagger_client.apis.concepts_api import ConceptsApi
@@ -5,11 +10,6 @@ from aou_workbench_client.swagger_client.models.domain import Domain
 from aou_workbench_client.swagger_client.models.search_concepts_request import SearchConceptsRequest
 from aou_workbench_client.swagger_client.models.standard_concept_filter import StandardConceptFilter
 from ipywidgets import interactive
-import html
-import json
-import pandas as pd
-
-from IPython.display import display, HTML
 
 _DOMAIN_DICT = { 
     '': None,
@@ -140,9 +140,6 @@ _CONCEPT_ROW_HTML_TEMPLATE = """
 """
 
 _VOCAB_DICT = {id: id for id in _VOCAB_IDS}
-
-def escape_for_js(str):
-
 
 def search_concepts(request):
     client = get_authenticated_swagger_client()

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -69,9 +69,9 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     variable_prefix = document.getElementById('variable_prefix');
     generate_code = document.getElementById('generate_code');
     max_results.disabled = false;
-    max_results.style.color = '#FFFFFF';
+    max_results.style.backgroundColor = '#FFFFFF';
     variable_prefix.disabled = false;
-    variable_prefix.style.color = '#FFFFFF';
+    variable_prefix.style.backgroundColor = '#FFFFFF';
     generate_code.disabled = false;
   }
 </script>
@@ -91,12 +91,12 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
    <tr style="background: white">
      <td style="background: white">Max results:</td>
      <td style="background: white"><input type="number" value="10" id="max_results" maxlength="5" 
-       style="color: #DDDDDD" disabled="true"/></td>
+       style="background-color: #DDDDDD" disabled="true"/></td>
    </tr>
    <tr style="background: white">
      <td style="background: white">Variable prefix:</td>
      <td style="background: white"><input type="text" value="results" id="variable_prefix" maxlength="20" 
-       style="color: #DDDDDD" disabled="true"/>
+       style="background-color: #DDDDDD" disabled="true"/>
    </tr>
    <tr style="background: white">
      <td style="background: white"><input type="button" value="Generate code" id="generate_code" 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -108,7 +108,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   function generate_python_code() {
     max_results = document.getElementById('max_results').value;
     prefix = document.getElementById('variable_prefix').value;
-    cohort_name = json.dumps(document.getElementById('cohort_name').value);
+    cohort_name = JSON.stringify(document.getElementById('cohort_name').value);
     domain = selected_data['domain'];
     table_data = domain_to_table_map[domain];
     if (!table_data) {

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -69,7 +69,9 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     variable_prefix = document.getElementById('variable_prefix');
     generate_code = document.getElementById('generate_code');
     max_results.disabled = false
+    max_results.style.color = '#FFFFFF'
     variable_prefix.disabled = false
+    variable_prefix.style.color = '#FFFFFF'    
     generate_code.disabled = false
   }
 </script>
@@ -88,14 +90,17 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 <table style="background: white">
    <tr style="background: white">
      <td style="background: white">Max results:</td>
-     <td style="background: white"><input type="number" value="10" id="max_results" maxlength="5" disabled="true"/></td>
+     <td style="background: white"><input type="number" value="10" id="max_results" maxlength="5" 
+       style="color: #DDDDDD" disabled="true"/></td>
    </tr>
    <tr style="background: white">
      <td style="background: white">Variable prefix:</td>
-     <td style="background: white"><input type="text" value="results" id="variable_prefix" maxlength="20" disabled="true"/>
+     <td style="background: white"><input type="text" value="results" id="variable_prefix" maxlength="20" 
+       style="color: #DDDDDD" disabled="true"/>
    </tr>
    <tr style="background: white">
-     <td style="background: white"><input type="button" value="Generate code" id="generate_code" disabled="true"/>
+     <td style="background: white"><input type="button" value="Generate code" id="generate_code" 
+       disabled="true"/>
    </tr>
 </table>
 """

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -118,19 +118,18 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
       column = table_data[2];
     }
     materialization_code = `
-      from aou_workbench_client.swagger_client.models import ResultFilters, MaterializeCohortRequest
-      from aou_workbench_client.swagger_client.models import TableQuery, ColumnFilter, FieldSet
-      from aou_workbench_client.cohorts import materialize_cohort
-      from aou_workbench_client.cdr.model import ${table}
-      import pandas as pd
+from aou_workbench_client.swagger_client.models import ResultFilters, MaterializeCohortRequest
+from aou_workbench_client.swagger_client.models import TableQuery, ColumnFilter, FieldSet
+from aou_workbench_client.cohorts import materialize_cohort
+from aou_workbench_client.cdr.model import ${table}
+import pandas as pd
     
-      # Filter on "${selected_data['name']}" (vocabulary = ${selected_data['vocabulary']}, concept ID = ${selected_row_id})
-      ${prefix}_filter = ColumnFilter(${table}.${column}, value_number=${selected_row_id})
-      ${prefix}_query = TableQuery(table=${table}, filters=ResultFilters(column_filter=${prefix}_filter))
-      ${prefix}_request = MaterializeCohortRequest(cohort_name="COHORT NAME HERE", field_set=FieldSet(table_query=${prefix}_query))
-      ${prefix}_response = materialize_cohort(${prefix}_request, max_results=${max_results})
-      ${prefix}_frame = pd.DataFrame(list(${prefix}_response))
-    `;
+# Filter on "${selected_data['name']}" (vocabulary = ${selected_data['vocabulary']}, concept ID = ${selected_row_id})
+${prefix}_filter = ColumnFilter(${table}.${column}, value_number=${selected_row_id})
+${prefix}_query = TableQuery(table=${table}, filters=ResultFilters(column_filter=${prefix}_filter))
+${prefix}_request = MaterializeCohortRequest(cohort_name="COHORT NAME HERE", field_set=FieldSet(table_query=${prefix}_query))
+${prefix}_response = materialize_cohort(${prefix}_request, max_results=${max_results})
+${prefix}_frame = pd.DataFrame(list(${prefix}_response))`;
     new_cell = IPython.notebook.insert_cell_below('code');
     new_cell.set_text(materialization_code);
   }
@@ -155,7 +154,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
    </tr>
    <tr style="background: white">
      <td style="background: white">Variable prefix:</td>
-     <td style="background: white"><input type="text" value="prefix" id="variable_prefix" maxlength="20" 
+     <td style="background: white"><input type="text" value="results_" id="variable_prefix" maxlength="20" 
        style="color: #999999" disabled="true"/>
    </tr>
    <tr style="background: white">

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -90,7 +90,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     new_selected_row.style.backgroundColor = '#BBBBFF';    
   }
   
-  function generate_code() {
+  function generate_python_code() {
     var kernel = IPython.notebook.kernel;
     cell_text = 'id = ' + selected_row_id;
     command = 'get_ipython().set_next_input("' + cell_text + '")';
@@ -123,7 +123,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
    <tr style="background: white">
      <td style="background: white"><input type="button" value="Generate code" id="generate_code" 
        class="p-Widget jupyter-widgets jupyter-button widget-button" disabled="true"
-       onclick="generate_code()"/>
+       onclick="generate_python_code()"/>
    </tr>
 </table>
 """

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -65,9 +65,19 @@ _RESULT_FIELDS = [
 _CONCEPT_TABLE_HTML_TEMPLATE = """
 <script language="javascript">
   function select_concept(id, domain) {
-    alert('id = ' + id + ', domain = ' + domain)
+    max_results = document.getElementById('max_results');
+    variable_prefix = document.getElementById('variable_prefix');
+    generate_code = document.getElementById('generate_code');
+    max_results.disabled = false
+    variable_prefix.disabled = false
+    generate_code.disabled = false
   }
 </script>
+
+<style>
+  .form {
+  }
+</style>
 
 <table>
   <tr>
@@ -79,6 +89,19 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     <th align=right>Count</th>
   </tr>
   %s
+</table>
+<table class="form">
+   <tr>
+     <td>Max results:</td>
+     <td><input type="number" value="10" id="max_results" maxlength="5" disabled="true"/></td>
+   </tr>
+   <tr>
+     <td>Variable prefix:</td>
+     <td><input type="text" value="results" id="variable_prefix" maxlength="20" disabled="true"/>
+   </tr>
+   <tr>
+     <td><input type="button" value="Generate code" id="generate_code" disabled="true"/>
+   </tr>
 </table>
 """
 
@@ -125,7 +148,7 @@ def display_concepts(request):
     display(HTML(table_html))
 
 def display_concepts_fn(query, domain, vocabulary, concepts):
-    request = SearchConceptsRequest(query=query)
+    request = SearchConceptsRequest(query=query, max_results=10)
     if domain:
         request.domain = domain
     if concepts:

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -92,7 +92,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   
   function generate_python_code() {
     var kernel = IPython.notebook.kernel;
-    cell_text = 'from nbformat import v4 as nbf\n';
+    cell_text = 'from nbformat import v4 as nbf\\n';
     cell_text += 'nbf.new_code_cell("print \\'foo\\'")';
     command = 'get_ipython().set_next_input("' + cell_text + '")';
     alert(command);

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -130,9 +130,9 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
       ${prefix}_request = MaterializeCohortRequest(cohort_name="COHORT NAME HERE", field_set=FieldSet(table_query=${prefix}_query))
       ${prefix}_response = materialize_cohort(${prefix}_request, max_results=${max_results})
       ${prefix}_frame = pd.DataFrame(list(${prefix}_response))
-    `
-    new_cell = IPython.notebook.insert_cell_below('code')    
-    new_cell.set_text(materialization_code)  
+    `;
+    new_cell = IPython.notebook.insert_cell_below('code');
+    new_cell.set_text(materialization_code);
   }
 </script>
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -66,7 +66,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 <table>
   <tr>
     <th>ID</th>
-    <th align=left>Name</th>
+    <th style="text-align: left">Name</th>
     <th>Code</th>
     <th>Domain</th>
     <th>Vocabulary</th>
@@ -79,7 +79,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 _CONCEPT_ROW_HTML_TEMPLATE = """
   <tr>
     <td>%d</td>
-    <td align=left>%s</td>
+    <td style="text-align: left">%s</td>
     <td>%s</td>
     <td>%s</td>
     <td>%s</td>

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -66,7 +66,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 <table>
   <tr>
     <th>ID</th>
-    <th>Name</th>
+    <th align=left>Name</th>
     <th>Code</th>
     <th>Domain</th>
     <th>Vocabulary</th>
@@ -79,11 +79,11 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 _CONCEPT_ROW_HTML_TEMPLATE = """
   <tr>
     <td>%d</td>
+    <td align=left>%s</td>
     <td>%s</td>
     <td>%s</td>
     <td>%s</td>
-    <td>%s</td>
-    <td align=right>%d</td>
+    <td>%d</td>
   </tr>
 """
 
@@ -98,7 +98,7 @@ def search_concepts(request):
     return response.items
 
 def get_concept_dict(concept):
-    return {f[0]: getattr(concept, f[1]) for f in _RESULT_FIELDS} 
+    return {f[0]: getattr(concept, f[1]) for f in _RESULT_FIELDS}
 
 def get_concepts_frame(request):
     concepts = search_concepts(request)

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -105,7 +105,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   
   function generate_python_code() {
     max_results = document.getElementById('max_results').value;
-    prefix = document.getElementById('prefix').value;
+    prefix = document.getElementById('variable_prefix').value;
     domain = selected_data['domain'];
     table_data = domain_to_table_map[domain];
     if (!table_data) {

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -92,8 +92,8 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   
   function generate_code() {
     var kernel = IPython.notebook.kernel;
-    cell_text = 'id = ' + selected_row_id + ', domain = ' + selected_row_domain;    
-    command = 'get_ipython().set_next_input(' + cell_text + ')';
+    cell_text = 'id = ' + selected_row_id;
+    command = 'get_ipython().set_next_input("' + cell_text + '")';
     kernel.execute(command);
   }
 </script>

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -94,6 +94,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     var kernel = IPython.notebook.kernel;
     cell_text = 'id = ' + selected_row_id;
     command = 'get_ipython().set_next_input("' + cell_text + '")';
+    alert(command);
     kernel.execute(command);
   }
 </script>

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -74,12 +74,6 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   }
 </script>
 
-<style type="text/css">
-  .form {
-    all: revert;
-  }
-</style>
-
 <table>
   <tr>
     <th>ID</th>
@@ -91,7 +85,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   </tr>
   %s
 </table>
-<table class="form">
+<table style="all: revert">
    <tr>
      <td>Max results:</td>
      <td><input type="number" value="10" id="max_results" maxlength="5" disabled="true"/></td>

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -91,11 +91,8 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   }
   
   function generate_python_code() {
-    var kernel = IPython.notebook.kernel;
-    cell_text = 'from nbformat import v4 as nbf\\n';
-    cell_text += 'nbf.new_code_cell("print \\'foo\\'")';
-    alert(cell_text);
-    kernel.execute(cell_text);
+    new_cell = IPython.notebook.insert_cell_below('code')
+    new_cell.set_text('print "foo"')
   }
 </script>
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -129,7 +129,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 """
 
 _CONCEPT_ROW_HTML_TEMPLATE = """
-  <tr id="row_{id}" onclick="select_concept('{id}', '{js_escaped_domain}')">
+  <tr id="row_{id}" onclick='select_concept("{id}", {js_escaped_domain})'>
     <td>{id}</td>
     <td style="text-align: left">{name}</td>
     <td style="text-align: left">{code}</td>
@@ -161,7 +161,6 @@ def display_concepts(request):
     concepts = search_concepts(request)
     row_html = ''
     for concept in concepts:
-      print json.dumps(concept.domain_id)
       row_html += _CONCEPT_ROW_HTML_TEMPLATE.format(id=concept.concept_id,
                                                     name=html.escape(concept.concept_name),
                                                     code=html.escape(concept.concept_code),

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -64,6 +64,9 @@ _RESULT_FIELDS = [
 
 _CONCEPT_TABLE_HTML_TEMPLATE = """
 <script language="javascript">
+  var selected_row_id = null;
+  var old_selected_color = null;
+  
   function select_concept(id, domain) {
     max_results = document.getElementById('max_results');
     variable_prefix = document.getElementById('variable_prefix');
@@ -73,6 +76,12 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     variable_prefix.disabled = false;
     variable_prefix.style.color = '';
     generate_code.disabled = false;
+    if (selected_row_id) {
+      document.getElementById(selected_row_id).style.backgroundColor = old_selected_color;
+    }
+    new_selected_row = document.getElementById('row_' + id);
+    old_selected_color = new_selected_row.style.backgroundColor;
+    new_selected_row.style.backgroundColor = '#3333FF';
   }
 </script>
 
@@ -106,7 +115,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 """
 
 _CONCEPT_ROW_HTML_TEMPLATE = """
-  <tr onclick="select_concept('{id}', '{domain}')">
+  <tr id="row_{id}" onclick="select_concept('{id}', '{domain}')">
     <td>{id}</td>
     <td style="text-align: left">{name}</td>
     <td style="text-align: left">{code}</td>

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -68,11 +68,11 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     max_results = document.getElementById('max_results');
     variable_prefix = document.getElementById('variable_prefix');
     generate_code = document.getElementById('generate_code');
-    max_results.disabled = false
-    max_results.style.color = '#FFFFFF'
-    variable_prefix.disabled = false
-    variable_prefix.style.color = '#FFFFFF'    
-    generate_code.disabled = false
+    max_results.disabled = false;
+    max_results.style.color = '#FFFFFF';
+    variable_prefix.disabled = false;
+    variable_prefix.style.color = '#FFFFFF';
+    generate_code.disabled = false;
   }
 </script>
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -94,7 +94,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   domain_to_table_map = {
     'Condition': ['ConditionOccurrence', 'condition_concept_id', 'condition_source_concept_id'],
     'Device': ['DeviceExposure', 'device_concept_id', 'device_source_concept_id'],
-    'Drug': ['DrugExposure' 'drug_concept_id', 'drug_source_concept_id'],
+    'Drug': ['DrugExposure', 'drug_concept_id', 'drug_source_concept_id'],
     'Ethnicity': ['Person', 'ethnicity_concept_id', 'ethnicity_source_concept_id'],
     'Gender': ['Person', 'gender_concept_id', 'gender_source_concept_id'],
     'Measurement': ['Measurement', 'measurement_concept_id', 'measurement_source_concept_id'],

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -100,7 +100,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
    </tr>
    <tr style="background: white">
      <td style="background: white"><input type="button" value="Generate code" id="generate_code" 
-       disabled="true"/>
+       class="p-Widget jupyter-widgets jupyter-button widget-button" disabled="true"/>
    </tr>
 </table>
 """

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -123,7 +123,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
    <tr style="background: white">
      <td style="background: white"><input type="button" value="Generate code" id="generate_code" 
        class="p-Widget jupyter-widgets jupyter-button widget-button" disabled="true"
-       onclick="generate_code()/>
+       onclick="generate_code()"/>
    </tr>
 </table>
 """

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -85,17 +85,17 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   </tr>
   %s
 </table>
-<table style="all: revert">
-   <tr>
-     <td>Max results:</td>
-     <td><input type="number" value="10" id="max_results" maxlength="5" disabled="true"/></td>
+<table style="background: white">
+   <tr style="background: white">
+     <td style="background: white">Max results:</td>
+     <td style="background: white"><input type="number" value="10" id="max_results" maxlength="5" disabled="true"/></td>
    </tr>
-   <tr>
-     <td>Variable prefix:</td>
-     <td><input type="text" value="results" id="variable_prefix" maxlength="20" disabled="true"/>
+   <tr style="background: white">
+     <td style="background: white">Variable prefix:</td>
+     <td style="background: white"><input type="text" value="results" id="variable_prefix" maxlength="20" disabled="true"/>
    </tr>
-   <tr>
-     <td><input type="button" value="Generate code" id="generate_code" disabled="true"/>
+   <tr style="background: white">
+     <td style="background: white"><input type="button" value="Generate code" id="generate_code" disabled="true"/>
    </tr>
 </table>
 """

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -92,8 +92,8 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   
   function generate_python_code() {
     var kernel = IPython.notebook.kernel;
-    cell_text = 'from nbformat import v4 as nbf\n'
-    cell_text += 'nbf.new_code_cell("print \\'foo\\'")'
+    cell_text = 'from nbformat import v4 as nbf\n';
+    cell_text += 'nbf.new_code_cell("print \\'foo\\'")';
     command = 'get_ipython().set_next_input("' + cell_text + '")';
     alert(command);
     kernel.execute(command);

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -94,9 +94,8 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     var kernel = IPython.notebook.kernel;
     cell_text = 'from nbformat import v4 as nbf\\n';
     cell_text += 'nbf.new_code_cell("print \\'foo\\'")';
-    command = 'get_ipython().set_next_input("' + cell_text + '")';
-    alert(command);
-    kernel.execute(command);
+    alert(cell_text);
+    kernel.execute(cell_text);
   }
 </script>
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -69,9 +69,9 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     variable_prefix = document.getElementById('variable_prefix');
     generate_code = document.getElementById('generate_code');
     max_results.disabled = false;
-    max_results.style.backgroundColor = '#FFFFFF';
+    max_results.style.color = '';
     variable_prefix.disabled = false;
-    variable_prefix.style.backgroundColor = '#FFFFFF';
+    variable_prefix.style.color = '';
     generate_code.disabled = false;
   }
 </script>
@@ -91,12 +91,12 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
    <tr style="background: white">
      <td style="background: white">Max results:</td>
      <td style="background: white"><input type="number" value="10" id="max_results" maxlength="5" 
-       style="background-color: #DDDDDD" disabled="true"/></td>
+       style="color: #999999" disabled="true"/></td>
    </tr>
    <tr style="background: white">
      <td style="background: white">Variable prefix:</td>
      <td style="background: white"><input type="text" value="results" id="variable_prefix" maxlength="20" 
-       style="background-color: #DDDDDD" disabled="true"/>
+       style="color: #999999" disabled="true"/>
    </tr>
    <tr style="background: white">
      <td style="background: white"><input type="button" value="Generate code" id="generate_code" 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -68,10 +68,11 @@ _RESULT_FIELDS = [
 _CONCEPT_TABLE_HTML_TEMPLATE = """
 <script language="javascript">
   var selected_row_id = null;
-  var selected_row_domain = null;
+  var selected_data = null;
+  
   var old_selected_color = null;
   
-  function select_concept(id, domain) {
+  function select_concept(id, name, domain, vocabulary, standard) {
     max_results = document.getElementById('max_results');
     variable_prefix = document.getElementById('variable_prefix');
     generate_code = document.getElementById('generate_code');
@@ -83,16 +84,55 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     if (selected_row_id) {
       document.getElementById('row_' + selected_row_id).style.backgroundColor = old_selected_color;
     }
-    selected_row_id = id
-    selected_row_domain = domain
+    selected_row_id = id;
+    selected_data = { 'name': name, 'domain': domain, 'vocabulary': vocabulary, 'standard': standard };
     new_selected_row = document.getElementById('row_' + id);
     old_selected_color = new_selected_row.style.backgroundColor;
     new_selected_row.style.backgroundColor = '#BBBBFF';    
   }
   
+  domain_to_table_map = {
+    'Condition': ['ConditionOccurrence', 'condition_concept_id', 'condition_source_concept_id'],
+    'Device': ['DeviceExposure', 'device_concept_id', 'device_source_concept_id'],
+    'Drug': ['DrugExposure' 'drug_concept_id', 'drug_source_concept_id'],
+    'Ethnicity': ['Person', 'ethnicity_concept_id', 'ethnicity_source_concept_id'],
+    'Gender': ['Person', 'gender_concept_id', 'gender_source_concept_id'],
+    'Measurement': ['Measurement', 'measurement_concept_id', 'measurement_source_concept_id'],
+    'Observation': ['Observation', 'observation_concept_id', 'observation_source_concept_id'],
+    'Procedure': ['ProcedureOccurrence', 'procedure_concept_id', 'procedure_source_concept_id'],
+    'Race': ['Person', 'race_concept_id', 'race_source_concept_id']
+  };
+  
   function generate_python_code() {
-    new_cell = IPython.notebook.insert_cell_below('code')
-    new_cell.set_text('print "foo"')
+    max_results = document.getElementById('max_results').value;
+    prefix = document.getElementById('prefix').value;
+    domain = selected_data['domain'];
+    table_data = domain_to_table_map[domain];
+    if (!table_data) {
+      return;
+    }
+    table = table_data[0];
+    if (selected_data['standard']) {
+      column = table_data[1];
+    } else {
+      column = table_data[2];
+    }
+    materialization_code = `
+      from aou_workbench_client.swagger_client.models import ResultFilters, MaterializeCohortRequest
+      from aou_workbench_client.swagger_client.models import TableQuery, ColumnFilter, FieldSet
+      from aou_workbench_client.cohorts import materialize_cohort
+      from aou_workbench_client.cdr.model import ${table}
+      import pandas as pd
+    
+      # Filter on "${selected_data['name']}" (vocabulary = ${selected_data['vocabulary']}, concept ID = ${selected_row_id})
+      ${prefix}_filter = ColumnFilter(${table}.${column}, value_number=${selected_row_id})
+      ${prefix}_query = TableQuery(table=${table}, filters=ResultFilters(column_filter=${prefix}_filter))
+      ${prefix}_request = MaterializeCohortRequest(cohort_name="COHORT NAME HERE", field_set=FieldSet(table_query=${prefix}_query))
+      ${prefix}_response = materialize_cohort(${prefix}_request, max_results=${max_results})
+      ${prefix}_frame = pd.DataFrame(list(${prefix}_response))
+    `
+    new_cell = IPython.notebook.insert_cell_below('code')    
+    new_cell.set_text(materialization_code)  
   }
 </script>
 
@@ -115,7 +155,7 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
    </tr>
    <tr style="background: white">
      <td style="background: white">Variable prefix:</td>
-     <td style="background: white"><input type="text" value="results" id="variable_prefix" maxlength="20" 
+     <td style="background: white"><input type="text" value="prefix" id="variable_prefix" maxlength="20" 
        style="color: #999999" disabled="true"/>
    </tr>
    <tr style="background: white">

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -63,13 +63,17 @@ _RESULT_FIELDS = [
     ('Count', 'count_value')]
 
 _CONCEPT_TABLE_HTML_TEMPLATE = """
+function select_concept(id, domain) {
+  alert('id = ' + id + ', domain = ' + domain)
+}
+
 <table>
   <tr>
     <th>ID</th>
     <th style="text-align: left">Name</th>
-    <th>Code</th>
-    <th>Domain</th>
-    <th>Vocabulary</th>
+    <th style="text-align: left">Code</th>
+    <th style="text-align: left">Domain</th>
+    <th style="text-align: left">Vocabulary</th>
     <th align=right>Count</th>
   </tr>
   %s
@@ -77,13 +81,13 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
 """
 
 _CONCEPT_ROW_HTML_TEMPLATE = """
-  <tr>
-    <td>%d</td>
-    <td style="text-align: left">%s</td>
-    <td>%s</td>
-    <td>%s</td>
-    <td>%s</td>
-    <td>%d</td>
+  <tr onclick="select_concept('{id}', '{domain}')">
+    <td>{id}</td>
+    <td style="text-align: left">{name}</td>
+    <td style="text-align: left">{code}</td>
+    <td style="text-align: left">{domain}</td>
+    <td style="text-align: left">{vocabulary}</td>
+    <td>{count}</td>
   </tr>
 """
 
@@ -109,9 +113,12 @@ def display_concepts(request):
     concepts = search_concepts(request)
     row_html = ''
     for concept in concepts:
-      row_html += _CONCEPT_ROW_HTML_TEMPLATE % (concept.concept_id, concept.concept_name,
-                                                concept.concept_code, concept.domain_id,
-                                                concept.vocabulary_id, concept.count_value)
+      row_html += _CONCEPT_ROW_HTML_TEMPLATE.format(id=concept.concept_id,
+                                                    name=concept.concept_name,
+                                                    code=concept.concept_code,
+                                                    domain=concept.domain_id,
+                                                    vocabulary=concept.vocabulary_id,
+                                                    count=concept.count_value)
     table_html = _CONCEPT_TABLE_HTML_TEMPLATE % row_html
     display(HTML(table_html))
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -74,8 +74,9 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
   }
 </script>
 
-<style>
+<style type="text/css">
   .form {
+    all: revert;
   }
 </style>
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -63,9 +63,11 @@ _RESULT_FIELDS = [
     ('Count', 'count_value')]
 
 _CONCEPT_TABLE_HTML_TEMPLATE = """
-function select_concept(id, domain) {
-  alert('id = ' + id + ', domain = ' + domain)
-}
+<script language="javascript">
+  function select_concept(id, domain) {
+    alert('id = ' + id + ', domain = ' + domain)
+  }
+</script>
 
 <table>
   <tr>

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -62,6 +62,31 @@ _RESULT_FIELDS = [
     ('Vocabulary', 'vocabulary_id'),
     ('Count', 'count_value')]
 
+_CONCEPT_TABLE_HTML_TEMPLATE = """
+<table>
+  <tr>
+    <th>ID</th>
+    <th>Name</th>
+    <th>Code</th>
+    <th>Domain</th>
+    <th>Vocabulary</th>
+    <th align=right>Count</th>
+  </tr>
+  %s
+</table>
+"""
+
+_CONCEPT_ROW_HTML_TEMPLATE = """
+  <tr>
+    <td>%d</td>
+    <td>%s</td>
+    <td>%s</td>
+    <td>%s</td>
+    <td>%s</td>
+    <td align=right>%d</td>
+  </tr>
+"""
+
 _VOCAB_DICT = {id: id for id in _VOCAB_IDS}
 
 def search_concepts(request):
@@ -81,11 +106,14 @@ def get_concepts_frame(request):
                         columns = [f[0] for f in _RESULT_FIELDS])
 
 def display_concepts(request):
-    concepts_frame = get_concepts_frame(request)
-    s = concepts_frame.style.set_properties(**{'text-align': 'left'})
-    s = s.set_table_styles(
-        [{"selector": "th", "props": [("text-align", "left")]}]).hide_index()
-    display(HTML(s.render()))
+    concepts = search_concepts(request)
+    row_html = ''
+    for concept in concepts:
+      row_html += _CONCEPT_ROW_HTML_TEMPLATE % (concept.concept_id, concept.concept_name,
+                                                concept.concept_code, concept.domain_id,
+                                                concept.vocabulary_id, concept.count_value)
+    table_html = _CONCEPT_TABLE_HTML_TEMPLATE % row_html
+    display(HTML(table_html))
 
 def display_concepts_fn(query, domain, vocabulary, concepts):
     request = SearchConceptsRequest(query=query)

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -77,11 +77,13 @@ _CONCEPT_TABLE_HTML_TEMPLATE = """
     variable_prefix.style.color = '';
     generate_code.disabled = false;
     if (selected_row_id) {
-      document.getElementById(selected_row_id).style.backgroundColor = old_selected_color;
+      document.getElementById('row_' + selected_row_id).style.backgroundColor = old_selected_color;
     }
+    selected_row_id = id
     new_selected_row = document.getElementById('row_' + id);
     old_selected_color = new_selected_row.style.backgroundColor;
-    new_selected_row.style.backgroundColor = '#3333FF';
+    new_selected_row.style.backgroundColor = '#BBBBFF';
+    
   }
 </script>
 

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -141,6 +141,9 @@ _CONCEPT_ROW_HTML_TEMPLATE = """
 
 _VOCAB_DICT = {id: id for id in _VOCAB_IDS}
 
+def escape_for_js(str):
+
+
 def search_concepts(request):
     client = get_authenticated_swagger_client()
     concepts_api = ConceptsApi(api_client=client)
@@ -161,6 +164,7 @@ def display_concepts(request):
     concepts = search_concepts(request)
     row_html = ''
     for concept in concepts:
+      print json.dumps(concept.domain_id)
       row_html += _CONCEPT_ROW_HTML_TEMPLATE.format(id=concept.concept_id,
                                                     name=html.escape(concept.concept_name),
                                                     code=html.escape(concept.concept_code),

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,4 +1,4 @@
 oauth2client>=4.0.0
-pandas>=0.17.1
+pandas>=0.17.1,<0.21
 ipython>=5.7.0
 ipywidgets>=7.2


### PR DESCRIPTION
Note: this is a prototype. It may make sense to move this sort of functionality into the chrome of notebooks, or to have Javascript served up from workbench rather than inlined in our client library like this. For now, hopefully is a good way to get some feedback.

When you first get concept search results you can select one and see a form for generating code:

<img width="1112" alt="screen shot 2018-05-31 at 4 48 28 pm" src="https://user-images.githubusercontent.com/12536316/40810292-fbe7f7ba-64f2-11e8-85f2-02de7fe77f17.png">

(The "Cohort" text box is intended to be replaced with a dropdown with a list of cohorts in the workspace.)

When you hit "Generate code" you get in a new cell, below the first one, this generated code (which you can then run to get results):

<img width="1110" alt="screen shot 2018-05-31 at 4 48 36 pm" src="https://user-images.githubusercontent.com/12536316/40810216-cd505e92-64f2-11e8-832a-b668e14e01be.png">
