### PR TITLE
[RW-977] Adding data.load_data_table method to Python client library.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
      steps:
       - checkout
       - run:
-          command: cat py/requirements.txt py/swagger-requirements.txt > all_requirements.txt
+          command: cat py/requirements.txt py/test/test-requirements.txt py/swagger-requirements.txt > all_requirements.txt
       - restore_cache:
           key: deps-{{ .Branch }}-{{ checksum "all_requirements.txt" }}
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .settings
 .project
 .pydevproject

--- a/libproject/devstart.rb
+++ b/libproject/devstart.rb
@@ -214,6 +214,7 @@ def install_py_requirements()
   common = Common.new
   common.run_inline %W{
       pip install --requirement #{File.join(py_root, "requirements.txt")}
+      --requirement #{File.join(py_root, "test", "test-requirements.txt")}
       --requirement #{File.join(py_root, "swagger-requirements.txt")}}
 end
 

--- a/libproject/devstart.rb
+++ b/libproject/devstart.rb
@@ -11,7 +11,7 @@ require_relative "../aou-utils/swagger"
 API_TAG = "api_v1_7"
 
 SWAGGER_SPEC = "https://raw.githubusercontent.com/all-of-us/workbench/#{API_TAG}/api/src/main/resources/client_api.yaml"
-CDM_SPEC = "https://raw.githubusercontent.com/all-of-us/workbench/master/api/config/cdm/cdm_5_2.json"
+CDM_SPEC = "https://raw.githubusercontent.com/all-of-us/workbench/1db7fc6df81c22a1d0c80e1c6862830f171239ea/api/config/cdm/cdm_5_2.json"
 TEST_PROJECT = "all-of-us-workbench-test"
 TABLE_QUERY_FILE_NAME = "py/aou_workbench_client/swagger_client/models/table_query.py"
 OPERATOR_FILE_NAME = "py/aou_workbench_client/swagger_client/models/operator.py"
@@ -92,8 +92,16 @@ def write_tables_python(f, tables, add_to_cohort_tables)
     f.puts('class ' + capitalize(table_name) + '(object):')    
     table_columns.each do |column|
       column_name = column['name']
-      f.puts('  ' + column_name + ' = "' + column_name + '"')           
-    end            
+      f.puts('  ' + column_name + ' = "' + column_name + '"')
+      domain_concept = column['domainConcept']
+      if domain_concept then
+         if domain_concept == 'standard' then
+           f.puts('  standard_concept_id_column = "' + column_name + '"')
+         else
+           f.puts('  source_concept_id_column = "' + column_name + '"')
+         end
+      end
+    end               
     f.puts('  table_name = "' + table_name + '"')
     f.puts('  columns = pd.DataFrame([' + 
         table_columns.map {|x| column_dict(x)}.join(',') + '],

--- a/libproject/devstart.rb
+++ b/libproject/devstart.rb
@@ -11,7 +11,7 @@ require_relative "../aou-utils/swagger"
 API_TAG = "api_v1_7"
 
 SWAGGER_SPEC = "https://raw.githubusercontent.com/all-of-us/workbench/#{API_TAG}/api/src/main/resources/client_api.yaml"
-CDM_SPEC = "https://raw.githubusercontent.com/all-of-us/workbench/1db7fc6df81c22a1d0c80e1c6862830f171239ea/api/config/cdm/cdm_5_2.json"
+CDM_SPEC = "https://raw.githubusercontent.com/all-of-us/workbench/master/api/config/cdm/cdm_5_2.json"
 TEST_PROJECT = "all-of-us-workbench-test"
 TABLE_QUERY_FILE_NAME = "py/aou_workbench_client/swagger_client/models/table_query.py"
 OPERATOR_FILE_NAME = "py/aou_workbench_client/swagger_client/models/operator.py"

--- a/py/README.md
+++ b/py/README.md
@@ -226,6 +226,7 @@ has:
 * a `foreign_keys` field containing a list of zero or more names of fields for foreign keys to related tables
 * fields for the names of columns on the table itself, which can be referenced in column filters (e.g. `Person.person_id`)
 * zero or more fields for referencing columns on related tables (e.g. `Person.gender_concept`)
+* for cohort tables, `standard_concept_id_column` and `source_concept_id_column` fields storing the names of columns for the standard and source concepts for the domain
 
 You can use foreign keys to reference fields on related tables many levels deep;
 for example, `Person.care_site.location.city'.

--- a/py/aou_workbench_client/cdr/model.py
+++ b/py/aou_workbench_client/cdr/model.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """ Model objects containing metadata on the tables and columns in the 
 curated data repository. These were automatically generated from the schema 
-found at https://raw.githubusercontent.com/all-of-us/workbench/master/api/config/cdm/cdm_5_2.json.
+found at https://raw.githubusercontent.com/all-of-us/workbench/1db7fc6df81c22a1d0c80e1c6862830f171239ea/api/config/cdm/cdm_5_2.json.
 """
 
 from .wrapper import RelatedTableWrapper
@@ -103,6 +103,7 @@ class ConditionOccurrence(object):
   condition_occurrence_id = "condition_occurrence_id"
   person_id = "person_id"
   condition_concept_id = "condition_concept_id"
+  standard_concept_id_column = "condition_concept_id"
   condition_start_date = "condition_start_date"
   condition_start_datetime = "condition_start_datetime"
   condition_end_date = "condition_end_date"
@@ -113,6 +114,7 @@ class ConditionOccurrence(object):
   visit_occurrence_id = "visit_occurrence_id"
   condition_source_value = "condition_source_value"
   condition_source_concept_id = "condition_source_concept_id"
+  source_concept_id_column = "condition_source_concept_id"
   condition_status_source_value = "condition_status_source_value"
   condition_status_concept_id = "condition_status_concept_id"
   table_name = "condition_occurrence"
@@ -128,8 +130,10 @@ class Death(object):
   death_datetime = "death_datetime"
   death_type_concept_id = "death_type_concept_id"
   cause_concept_id = "cause_concept_id"
+  standard_concept_id_column = "cause_concept_id"
   cause_source_value = "cause_source_value"
   cause_source_concept_id = "cause_source_concept_id"
+  source_concept_id_column = "cause_source_concept_id"
   table_name = "death"
   columns = pd.DataFrame([{"Name": "person_id", "Type": "integer", "Description": "A foreign key identifier to the deceased person. The demographic details of that person are stored in the person table."},{"Name": "death_date", "Type": "date", "Description": "The date the person was deceased. If the precise date including day or month is not known or not allowed, December is used as the default month, and the last day of the month the default day."},{"Name": "death_datetime", "Type": "timestamp", "Description": "The date and time the person was deceased. If the precise date including day or month is not known or not allowed, December is used as the default month, and the last day of the month the default day."},{"Name": "death_type_concept_id", "Type": "integer", "Description": "A foreign key referring to the predefined concept identifier in the Standardized Vocabularies reflecting how the death was represented in the source data."},{"Name": "cause_concept_id", "Type": "integer", "Description": "A foreign key referring to a standard concept identifier in the Standardized Vocabularies for conditions."},{"Name": "cause_source_value", "Type": "string", "Description": "The source code for the cause of death as it appears in the source data. This code is mapped to a standard concept in the Standardized Vocabularies and the original code is, stored here for reference."},{"Name": "cause_source_concept_id", "Type": "integer", "Description": "A foreign key to the concept that refers to the code used in the source. Note, this variable name is abbreviated to ensure it will be allowable across database platforms."}],
         columns=["Name", "Type", "Description"])
@@ -141,6 +145,7 @@ class DeviceExposure(object):
   device_exposure_id = "device_exposure_id"
   person_id = "person_id"
   device_concept_id = "device_concept_id"
+  standard_concept_id_column = "device_concept_id"
   device_exposure_start_date = "device_exposure_start_date"
   device_exposure_start_datetime = "device_exposure_start_datetime"
   device_exposure_end_date = "device_exposure_end_date"
@@ -152,6 +157,7 @@ class DeviceExposure(object):
   visit_occurrence_id = "visit_occurrence_id"
   device_source_value = "device_source_value"
   device_source_concept_id = "device_source_concept_id"
+  source_concept_id_column = "device_source_concept_id"
   table_name = "device_exposure"
   columns = pd.DataFrame([{"Name": "device_exposure_id", "Type": "integer", "Description": "A system-generated unique identifier for each Device Exposure."},{"Name": "person_id", "Type": "integer", "Description": "A foreign key identifier to the Person who is subjected to the Device. The demographic details of that person are stored in the Person table."},{"Name": "device_concept_id", "Type": "integer", "Description": "A foreign key that refers to a Standard Concept identifier in the Standardized Vocabularies for the Device concept."},{"Name": "device_exposure_start_date", "Type": "date", "Description": "The date the Device or supply was applied or used."},{"Name": "device_exposure_start_datetime", "Type": "timestamp", "Description": "The date and time the Device or supply was applied or used."},{"Name": "device_exposure_end_date", "Type": "date", "Description": "The date the Device or supply was removed from use."},{"Name": "device_exposure_end_datetime", "Type": "timestamp", "Description": "The date and time the Device or supply was removed from use."},{"Name": "device_type_concept_id", "Type": "integer", "Description": "A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of Device Exposure recorded. It indicates how the Device Exposure was represented in the source data."},{"Name": "unique_device_id", "Type": "string", "Description": "A UDI or equivalent identifying the instance of the Device used in the Person."},{"Name": "quantity", "Type": "integer", "Description": "The number of individual Devices used for the exposure."},{"Name": "provider_id", "Type": "integer", "Description": "A foreign key to the provider in the PROVIDER table who initiated of administered the Device."},{"Name": "visit_occurrence_id", "Type": "integer", "Description": "A foreign key to the visit in the VISIT_OCCURRENCE table during which the device was used."},{"Name": "device_source_value", "Type": "string", "Description": "The source code for the Device as it appears in the source data. This code is mapped to a standard Device Concept in the Standardized Vocabularies and the original code is stored here for reference."},{"Name": "device_source_concept_id", "Type": "integer", "Description": ""}],
         columns=["Name", "Type", "Description"])
@@ -163,6 +169,7 @@ class DrugExposure(object):
   drug_exposure_id = "drug_exposure_id"
   person_id = "person_id"
   drug_concept_id = "drug_concept_id"
+  standard_concept_id_column = "drug_concept_id"
   drug_exposure_start_date = "drug_exposure_start_date"
   drug_exposure_start_datetime = "drug_exposure_start_datetime"
   drug_exposure_end_date = "drug_exposure_end_date"
@@ -180,6 +187,7 @@ class DrugExposure(object):
   visit_occurrence_id = "visit_occurrence_id"
   drug_source_value = "drug_source_value"
   drug_source_concept_id = "drug_source_concept_id"
+  source_concept_id_column = "drug_source_concept_id"
   route_source_value = "route_source_value"
   dose_unit_source_value = "dose_unit_source_value"
   table_name = "drug_exposure"
@@ -193,6 +201,7 @@ class Measurement(object):
   measurement_id = "measurement_id"
   person_id = "person_id"
   measurement_concept_id = "measurement_concept_id"
+  standard_concept_id_column = "measurement_concept_id"
   measurement_date = "measurement_date"
   measurement_datetime = "measurement_datetime"
   measurement_type_concept_id = "measurement_type_concept_id"
@@ -206,6 +215,7 @@ class Measurement(object):
   visit_occurrence_id = "visit_occurrence_id"
   measurement_source_value = "measurement_source_value"
   measurement_source_concept_id = "measurement_source_concept_id"
+  source_concept_id_column = "measurement_source_concept_id"
   unit_source_value = "unit_source_value"
   value_source_value = "value_source_value"
   table_name = "measurement"
@@ -219,6 +229,7 @@ class Observation(object):
   observation_id = "observation_id"
   person_id = "person_id"
   observation_concept_id = "observation_concept_id"
+  standard_concept_id_column = "observation_concept_id"
   observation_date = "observation_date"
   observation_datetime = "observation_datetime"
   observation_type_concept_id = "observation_type_concept_id"
@@ -234,6 +245,7 @@ class Observation(object):
   unit_source_value = "unit_source_value"
   qualifier_source_value = "qualifier_source_value"
   value_source_concept_id = "value_source_concept_id"
+  source_concept_id_column = "value_source_concept_id"
   value_source_value = "value_source_value"
   questionnaire_response_id = "questionnaire_response_id"
   table_name = "observation"
@@ -273,6 +285,7 @@ class ProcedureOccurrence(object):
   procedure_occurrence_id = "procedure_occurrence_id"
   person_id = "person_id"
   procedure_concept_id = "procedure_concept_id"
+  standard_concept_id_column = "procedure_concept_id"
   procedure_date = "procedure_date"
   procedure_datetime = "procedure_datetime"
   procedure_type_concept_id = "procedure_type_concept_id"
@@ -282,6 +295,7 @@ class ProcedureOccurrence(object):
   visit_occurrence_id = "visit_occurrence_id"
   procedure_source_value = "procedure_source_value"
   procedure_source_concept_id = "procedure_source_concept_id"
+  source_concept_id_column = "procedure_source_concept_id"
   qualifier_source_value = "qualifier_source_value"
   table_name = "procedure_occurrence"
   columns = pd.DataFrame([{"Name": "procedure_occurrence_id", "Type": "integer", "Description": "A system-generated unique identifier for each Procedure Occurrence."},{"Name": "person_id", "Type": "integer", "Description": "A foreign key identifier to the Person who is subjected to the Procedure. The demographic details of that Person are stored in the PERSON table."},{"Name": "procedure_concept_id", "Type": "integer", "Description": "A foreign key that refers to a standard procedure Concept identifier in the Standardized Vocabularies."},{"Name": "procedure_date", "Type": "date", "Description": "The date on which the Procedure was performed."},{"Name": "procedure_datetime", "Type": "timestamp", "Description": "The date and time on which the Procedure was performed."},{"Name": "procedure_type_concept_id", "Type": "integer", "Description": "A foreign key to the predefined Concept identifier in the Standardized Vocabularies reflecting the type of source data from which the procedure record is derived."},{"Name": "modifier_concept_id", "Type": "integer", "Description": "A foreign key to a Standard Concept identifier for a modifier to the Procedure (e.g. bilateral)"},{"Name": "quantity", "Type": "integer", "Description": "The quantity of procedures ordered or administered."},{"Name": "provider_id", "Type": "integer", "Description": "A foreign key to the provider in the PROVIDER table who was responsible for carrying out the procedure."},{"Name": "visit_occurrence_id", "Type": "integer", "Description": "A foreign key to the Visit in the VISIT_OCCURRENCE table during which the Procedure was carried out."},{"Name": "procedure_source_value", "Type": "string", "Description": "The source code for the Procedure as it appears in the source data. This code is mapped to a standard procedure Concept in the Standardized Vocabularies and the original code is, stored here for reference. Procedure source codes are typically ICD-9-Proc, CPT-4, HCPCS or OPCS-4 codes."},{"Name": "procedure_source_concept_id", "Type": "integer", "Description": "A foreign key to a Procedure Concept that refers to the code used in the source."},{"Name": "qualifier_source_value", "Type": "string", "Description": ""}],
@@ -294,6 +308,7 @@ class VisitOccurrence(object):
   visit_occurrence_id = "visit_occurrence_id"
   person_id = "person_id"
   visit_concept_id = "visit_concept_id"
+  standard_concept_id_column = "visit_concept_id"
   visit_start_date = "visit_start_date"
   visit_start_datetime = "visit_start_datetime"
   visit_end_date = "visit_end_date"
@@ -303,6 +318,7 @@ class VisitOccurrence(object):
   care_site_id = "care_site_id"
   visit_source_value = "visit_source_value"
   visit_source_concept_id = "visit_source_concept_id"
+  source_concept_id_column = "visit_source_concept_id"
   admitting_source_concept_id = "admitting_source_concept_id"
   admitting_source_value = "admitting_source_value"
   discharge_to_concept_id = "discharge_to_concept_id"

--- a/py/aou_workbench_client/cdr/model.py
+++ b/py/aou_workbench_client/cdr/model.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """ Model objects containing metadata on the tables and columns in the 
 curated data repository. These were automatically generated from the schema 
-found at https://raw.githubusercontent.com/all-of-us/workbench/1db7fc6df81c22a1d0c80e1c6862830f171239ea/api/config/cdm/cdm_5_2.json.
+found at https://raw.githubusercontent.com/all-of-us/workbench/master/api/config/cdm/cdm_5_2.json.
 """
 
 from .wrapper import RelatedTableWrapper

--- a/py/aou_workbench_client/cohorts.py
+++ b/py/aou_workbench_client/cohorts.py
@@ -3,17 +3,17 @@ from aou_workbench_client.config import all_of_us_config
 from aou_workbench_client.swagger_client.apis.cohorts_api import CohortsApi
 from copy import deepcopy
 
-def materialize_cohort_page(request):
+def materialize_cohort_page(request, debug=False):
     """Returns a MaterializeCohortResponse representing a page of results
     from materializing a cohort in the workspace containing this notebook, based
     on the provided MateralizeCohortRequest."""
-    client = get_authenticated_swagger_client()
+    client = get_authenticated_swagger_client(debug=debug)
     cohorts_api = CohortsApi(api_client=client)
     return cohorts_api.materialize_cohort(all_of_us_config.workspace_namespace,
                                           all_of_us_config.workspace_id,
                                           request=request)
 
-def materialize_cohort(request, max_results=None):
+def materialize_cohort(request, max_results=None, debug=False):
     """Materializes a cohort in the workspace containing this notebook, based
     on the provided MateralizeCohortRequest. Returns a generator of
     dictionaries containing the results.
@@ -24,7 +24,7 @@ def materialize_cohort(request, max_results=None):
     Multiple server requests may be made to retrieve all the results,
     using the page_size specified in the request for each request.
     """
-    client = get_authenticated_swagger_client()
+    client = get_authenticated_swagger_client(debug=debug)
     cohorts_api = CohortsApi(api_client=client)
 
     num_results = 0

--- a/py/aou_workbench_client/data.py
+++ b/py/aou_workbench_client/data.py
@@ -1,4 +1,5 @@
-from aou_workbench_client.swagger_client.models.materialize_cohort_request import MaterializeCohortRequest
+from aou_workbench_client.swagger_client.models.materialize_cohort_request import \
+    MaterializeCohortRequest
 from aou_workbench_client.swagger_client.models.table_query import TableQuery
 from aou_workbench_client.swagger_client.models.field_set import FieldSet
 from aou_workbench_client.swagger_client.models.column_filter import ColumnFilter
@@ -6,48 +7,85 @@ from aou_workbench_client.swagger_client.models.operator import Operator
 from aou_workbench_client.swagger_client.models.result_filters import ResultFilters
 from aou_workbench_client.cohorts import materialize_cohort
 
+"""
+Loads a data table for participants in a specified cohort.
+
+  :param cohort_name: the name of a cohort in the workspace that contains the calling notebook
+  :param table: the class corresponding to the table that the data table should be extracted 
+    from, pulled from aou_workbench_client.cdr.model; e.g. aou_workbench_client.cdr.model.Person
+  :param columns: a list of column names from the table or related tables to return in the data table; 
+    defaults to all columns in the table (and no columns in related tables); 
+    e.g. [Person.person_id, Person.gender_concept_id]
+  :param concept_ids: a list of integer IDs of standard concepts to include in the results from
+    the table; only use with tables that have a standard_concept_id_column field on the provided
+    table class; defaults to no standard concept filtering. 
+    If both concept_ids and source_concept_ids are specified, rows that match either will be 
+    returned.
+  :param source_concept_ids: a list of integer IDs of source concepts to include in the results
+    from the table; only use with tables that have a source_concept_id_column field on the provided
+    table class; defaults to no standard concept filtering.
+    If both concept_ids and source_concept_ids are specified, rows that match either will be 
+    returned.
+  :param filters: other column filters to use to select rows returned from the table; defaults to
+    no additional filtering. If both filters and concept_ids / source_concept_ids are specified,
+    rows returned will match both.
+  :param cohort_statuses: a list of CohortStatus indicating a filter on the review status of 
+    participants to be returned in the resulting data table; defaults to no filtering (all 
+    participants are returned.
+  :param max_results: the maximum number of rows to return in the resulting data table; defaults
+    to no limit (all matching rows will be returned.) Note that for large cohorts, it may take a 
+    long time to get all results.
+  :param order_by: a list of column names from the table or related tables to order the results by; 
+    defaults to order by person_id and primary key of the specified table; e.g. 
+    [Person.gender_concept_id, Person.person_id]
+  :param page_size: the maximum number of result rows to fetch in a single API request when 
+    retrieving results; defaults to 1000.
+  :param debug: true if debug request and response information should be displayed; defaults to 
+    false.  
+"""
+
+
 def load_data_table(cohort_name, table, columns=None, concept_ids=None,
                     source_concept_ids=None, filters=None,
                     cohort_statuses=None, max_results=None,
                     order_by=None, page_size=None, debug=False):
-  all_filters = filters
-  concept_filters = []
-  if concept_ids:
-    standard_concept_id_column = getattr(table, 'standard_concept_id_column')
-    if not standard_concept_id_column:
-      raise "Could not find standard concept id column for table " + table.table_name
-    column_filter = ColumnFilter(column_name=standard_concept_id_column,
-                                 value_numbers=concept_ids,
-                                 operator=Operator.IN)
-    concept_filters.append(ResultFilters(column_filter=column_filter))
-  if source_concept_ids:
-    source_concept_id_column = getattr(table, 'source_concept_id_column')
-    if not source_concept_id_column:
-      raise "Could not find source concept id column for table " + table.table_name
-    column_filter = ColumnFilter(column_name=source_concept_id_column,
-                                 value_numbers=source_concept_ids,
-                                 operator=Operator.IN)
-    concept_filters.append(ResultFilters(column_filter=column_filter))
-    
-  if concept_filters:
-    concept_result_filters = None    
-    if len(concept_filters) == 1:
-      concept_result_filters = concept_filters[0]
-    else:
-      # If standard and source concept ids are provided, match either.
-      concept_result_filters = ResultFilters(any_of=concept_filters)
-    
-    if all_filters:
-      all_filters = ResultFilters(all_of=[all_filters, concept_result_filters])
-    else:
-      # If concept ids and other filters are provided, match both.
-      all_filters = concept_result_filters
-    
-  table_query = TableQuery(table=table, columns=columns, filters=all_filters,
-                           order_by=order_by)
-  field_set = FieldSet(table_query)
-  request = MaterializeCohortRequest(cohort_name=cohort_name, 
-                                     field_set=field_set,
-                                     page_size=page_size)
-  return materialize_cohort(request, max_results=max_results, debug=debug)
-  
+    all_filters = filters
+    concept_filters = []
+    if concept_ids:
+        standard_concept_id_column = getattr(table, 'standard_concept_id_column')
+        if not standard_concept_id_column:
+            raise "Could not find standard concept id column for table " + table.table_name
+        column_filter = ColumnFilter(column_name=standard_concept_id_column,
+                                     value_numbers=concept_ids,
+                                     operator=Operator.IN)
+        concept_filters.append(ResultFilters(column_filter=column_filter))
+    if source_concept_ids:
+        source_concept_id_column = getattr(table, 'source_concept_id_column')
+        if not source_concept_id_column:
+            raise "Could not find source concept id column for table " + table.table_name
+        column_filter = ColumnFilter(column_name=source_concept_id_column,
+                                     value_numbers=source_concept_ids,
+                                     operator=Operator.IN)
+        concept_filters.append(ResultFilters(column_filter=column_filter))
+
+    # If both standard and source concept ids are provided, match either.
+    if concept_filters:
+        concept_result_filters = None
+        if len(concept_filters) == 1:
+            concept_result_filters = concept_filters[0]
+        else:
+            concept_result_filters = ResultFilters(any_of=concept_filters)
+
+        if all_filters:
+            all_filters = ResultFilters(all_of=[all_filters, concept_result_filters])
+        else:
+            # If concept ids and other filters are provided, match both.
+            all_filters = concept_result_filters
+
+    table_query = TableQuery(table=table, columns=columns, filters=all_filters,
+                             order_by=order_by)
+    field_set = FieldSet(table_query)
+    request = MaterializeCohortRequest(cohort_name=cohort_name,
+                                       field_set=field_set,
+                                       page_size=page_size)
+    return materialize_cohort(request, max_results=max_results, debug=debug)

--- a/py/aou_workbench_client/data.py
+++ b/py/aou_workbench_client/data.py
@@ -9,7 +9,7 @@ from aou_workbench_client.cohorts import materialize_cohort
 def load_data_table(cohort_name, table, columns=None, concept_ids=None,
                     source_concept_ids=None, filters=None,
                     cohort_statuses=None, max_results=None,
-                    order_by=None, page_size=None):
+                    order_by=None, page_size=None, debug=False):
   all_filters = filters
   concept_filters = []
   if concept_ids:
@@ -49,5 +49,5 @@ def load_data_table(cohort_name, table, columns=None, concept_ids=None,
   request = MaterializeCohortRequest(cohort_name=cohort_name, 
                                      field_set=field_set,
                                      page_size=page_size)
-  return materialize_cohort(request, max_results=max_results)
+  return materialize_cohort(request, max_results=max_results, debug=debug)
   

--- a/py/aou_workbench_client/data.py
+++ b/py/aou_workbench_client/data.py
@@ -3,7 +3,7 @@ from aou_workbench_client.swagger_client.models.table_query import TableQuery
 from aou_workbench_client.swagger_client.models.field_set import FieldSet
 from aou_workbench_client.swagger_client.models.column_filter import ColumnFilter
 from aou_workbench_client.swagger_client.models.operator import Operator
-from aou_workbench_client.swagger_client.models.result_filters import ResultFilter
+from aou_workbench_client.swagger_client.models.result_filters import ResultFilters
 from aou_workbench_client.swagger_client.models.annotation_query import AnnotationQuery
 from aou_workbench_client.swagger_client.cohorts import materialize_cohort
 

--- a/py/aou_workbench_client/data.py
+++ b/py/aou_workbench_client/data.py
@@ -47,7 +47,7 @@ def load_data_table(cohort_name, table, columns=None, concept_ids=None,
                            order_by=order_by)
   field_set = FieldSet(table_query)
   request = MaterializeCohortRequest(cohort_name=cohort_name, 
-                                     table_query=table_query,
+                                     field_set=field_set,
                                      page_size=page_size)
   return materialize_cohort(request, max_results=max_results)
   

--- a/py/aou_workbench_client/data.py
+++ b/py/aou_workbench_client/data.py
@@ -4,8 +4,7 @@ from aou_workbench_client.swagger_client.models.field_set import FieldSet
 from aou_workbench_client.swagger_client.models.column_filter import ColumnFilter
 from aou_workbench_client.swagger_client.models.operator import Operator
 from aou_workbench_client.swagger_client.models.result_filters import ResultFilters
-from aou_workbench_client.swagger_client.models.annotation_query import AnnotationQuery
-from aou_workbench_client.swagger_client.cohorts import materialize_cohort
+from aou_workbench_client.cohorts import materialize_cohort
 
 def load_data_table(cohort_name, table, columns=None, concept_ids=None,
                     source_concept_ids=None, filters=None,

--- a/py/aou_workbench_client/data.py
+++ b/py/aou_workbench_client/data.py
@@ -1,0 +1,54 @@
+from aou_workbench_client.swagger_client.models.materialize_cohort_request import MaterializeCohortRequest
+from aou_workbench_client.swagger_client.models.table_query import TableQuery
+from aou_workbench_client.swagger_client.models.field_set import FieldSet
+from aou_workbench_client.swagger_client.models.column_filter import ColumnFilter
+from aou_workbench_client.swagger_client.models.operator import Operator
+from aou_workbench_client.swagger_client.models.result_filters import ResultFilter
+from aou_workbench_client.swagger_client.models.annotation_query import AnnotationQuery
+from aou_workbench_client.swagger_client.cohorts import materialize_cohort
+
+def load_data_table(cohort_name, table, columns=None, concept_ids=None,
+                    source_concept_ids=None, filters=None,
+                    cohort_statuses=None, max_results=None,
+                    order_by=None, page_size=None):
+  all_filters = filters
+  concept_filters = []
+  if concept_ids:
+    standard_concept_id_column = getattr(table, 'standard_concept_id_column')
+    if not standard_concept_id_column:
+      raise "Could not find standard concept id column for table " + table.table_name
+    column_filter = ColumnFilter(column_name=standard_concept_id_column,
+                                 value_numbers=concept_ids,
+                                 operator=Operator.IN)
+    concept_filters.append(ResultFilters(column_filter=column_filter))
+  if source_concept_ids:
+    source_concept_id_column = getattr(table, 'source_concept_id_column')
+    if not source_concept_id_column:
+      raise "Could not find source concept id column for table " + table.table_name
+    column_filter = ColumnFilter(column_name=source_concept_id_column,
+                                 value_numbers=source_concept_ids,
+                                 operator=Operator.IN)
+    concept_filters.append(ResultFilters(column_filter=column_filter))
+    
+  if concept_filters:
+    concept_result_filters = None    
+    if len(concept_filters) == 1:
+      concept_result_filters = concept_filters[0]
+    else:
+      # If standard and source concept ids are provided, match either.
+      concept_result_filters = ResultFilters(any_of=concept_filters)
+    
+    if all_filters:
+      all_filters = ResultFilters(all_of=[all_filters, concept_result_filters])
+    else:
+      # If concept ids and other filters are provided, match both.
+      all_filters = concept_result_filters
+    
+  table_query = TableQuery(table=table, columns=columns, filters=all_filters,
+                           order_by=order_by)
+  field_set = FieldSet(table_query)
+  request = MaterializeCohortRequest(cohort_name=cohort_name, 
+                                     table_query=table_query,
+                                     page_size=page_size)
+  return materialize_cohort(request, max_results=max_results)
+  

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,4 +1,2 @@
 oauth2client>=4.0.0
 pandas>=0.17.1,<0.21
-ipython>=5.7.0
-ipywidgets>=7.2

--- a/py/test/all_of_us_config.json
+++ b/py/test/all_of_us_config.json
@@ -1,8 +1,8 @@
 {
-  "WORKSPACE_ID": "mynewworkspace",
+  "WORKSPACE_ID": "testing",
   "API_HOST": "api-dot-all-of-us-workbench-test.appspot.com",
   "CDR_VERSION_BIGQUERY_DATASET": "test_merge_dec26",
-  "WORKSPACE_NAMESPACE": "aou-test-f1-2",
-  "BUCKET_NAME": "fc-aeff9de0-235c-4338-b735-3cbd4d5db50c",
+  "WORKSPACE_NAMESPACE": "aou-rw-test-158-1",
+  "BUCKET_NAME": "fc-a7da7a8a-7a69-423b-a606-6f2cde64de34",
   "CDR_VERSION_CLOUD_PROJECT": "all-of-us-ehr-dev"
 }

--- a/py/test/cohorts_api_test.py
+++ b/py/test/cohorts_api_test.py
@@ -40,6 +40,12 @@ class CohortsApiTest(unittest.TestCase):
     def test_materialize_cohort(self):
         request = MaterializeCohortRequest(cohort_name='Old Men', page_size=10)
         results = list(materialize_cohort(request, max_results=20))
-        self.assertEqual(20, len(results))      
+        self.assertEqual(20, len(results))   
+        
+    def test_load_data_table(self):
+        response = load_data_table(cohort_name='Old Men', table=Person,
+                                   columns=[Person.person_id],
+                                   page_size=10, max_results=10)
+        self.assertEqual(10, len(list(response)))
       
       

--- a/py/test/cohorts_api_test.py
+++ b/py/test/cohorts_api_test.py
@@ -17,7 +17,7 @@ class CohortsApiTest(unittest.TestCase):
       
         # Grab the next page
         request.page_token = response.next_page_token
-        response_2 = materialize_cohort_page(request)
+        response_2 = materialize_cohort_page(request, debug=True)
         self.assertEqual(10, len(response_2.results))
         self.assertIsNotNone(response_2.next_page_token)
         self.assertNotEqual(response_2.results, response.results)
@@ -40,7 +40,7 @@ class CohortsApiTest(unittest.TestCase):
       
     def test_materialize_cohort(self):
         request = MaterializeCohortRequest(cohort_name='Old Men', page_size=10)
-        results = list(materialize_cohort(request, max_results=20))
+        results = list(materialize_cohort(request, max_results=20, debug=True))
         self.assertEqual(20, len(results))   
         
     def test_load_data_table(self):

--- a/py/test/cohorts_api_test.py
+++ b/py/test/cohorts_api_test.py
@@ -17,7 +17,7 @@ class CohortsApiTest(unittest.TestCase):
       
         # Grab the next page
         request.page_token = response.next_page_token
-        response_2 = materialize_cohort_page(request, debug=True)
+        response_2 = materialize_cohort_page(request)
         self.assertEqual(10, len(response_2.results))
         self.assertIsNotNone(response_2.next_page_token)
         self.assertNotEqual(response_2.results, response.results)

--- a/py/test/cohorts_api_test.py
+++ b/py/test/cohorts_api_test.py
@@ -5,6 +5,7 @@ from aou_workbench_client.cohorts import materialize_cohort_page, materialize_co
 from aou_workbench_client.swagger_client.models import MaterializeCohortRequest
 from aou_workbench_client.swagger_client.models import TableQuery, FieldSet
 from aou_workbench_client.cdr.model import Person
+from aou_workbench_client.data import load_data_table
 
 class CohortsApiTest(unittest.TestCase):
 

--- a/py/test/cohorts_api_test.py
+++ b/py/test/cohorts_api_test.py
@@ -17,7 +17,7 @@ class CohortsApiTest(unittest.TestCase):
       
         # Grab the next page
         request.page_token = response.next_page_token
-        response_2 = materialize_cohort_page(request, debug=True)
+        response_2 = materialize_cohort_page(request)
         self.assertEqual(10, len(response_2.results))
         self.assertIsNotNone(response_2.next_page_token)
         self.assertNotEqual(response_2.results, response.results)
@@ -40,7 +40,7 @@ class CohortsApiTest(unittest.TestCase):
       
     def test_materialize_cohort(self):
         request = MaterializeCohortRequest(cohort_name='Old Men', page_size=10)
-        results = list(materialize_cohort(request, max_results=20, debug=True))
+        results = list(materialize_cohort(request, max_results=20))
         self.assertEqual(20, len(results))   
         
     def test_load_data_table(self):

--- a/py/test/test-requirements.txt
+++ b/py/test/test-requirements.txt
@@ -1,0 +1,5 @@
+# We don't install these in requirements.txt so that we don't try to clobber
+# the version of Jupyter installed on a notebook cluster; see
+# https://github.com/DataBiosphere/leonardo/issues/417.
+ipython>=5.7.0
+ipywidgets>=7.2


### PR DESCRIPTION
Allows for simpler, one-line cohort materialization, without making a bunch of objects.

Uses new source_concept_id_column and standard_concept_id_column fields on model objects.

Updating all_of_us_config.json file used to run tests to point at new workspace.