### PR TITLE
[RW-843] Drop get_concepts_frame method

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -100,15 +100,6 @@ count order; the concepts that occur for the most participants in the CDR are re
 Use this function if you want access to the full [Concept](swagger_docs/Concept.md) data
 in your code.
 
-### `aou_workbench_client.concepts.get_concepts_frame`
-
-`get_concepts_frame` returns a DataFrame from the constructed from the results of calling `search_concepts`,
-with columns for concept ID, name, code, domain, vocabulary, and count.
-
-Use this function if you want to get back a data frame but have control over its
-rendering.
-
-
 ## Using cohorts
 
 The `aou_workbench_client.cohorts` module provides functions for retrieving data about participants

--- a/py/aou_workbench_client/concepts.py
+++ b/py/aou_workbench_client/concepts.py
@@ -204,14 +204,6 @@ def search_concepts(request):
                                             request=request)
     return response.items
 
-def get_concept_dict(concept):
-    return {f[0]: getattr(concept, f[1]) for f in _RESULT_FIELDS}
-
-def get_concepts_frame(request):
-    concepts = search_concepts(request)
-    return pd.DataFrame([get_concept_dict(concept) for concept in concepts],
-                        columns = [f[0] for f in _RESULT_FIELDS])
-
 def display_concepts(request):
     concepts = search_concepts(request)
     row_html = ''


### PR DESCRIPTION
Note: this is a breaking change.

This method is asymmetric to our cohort materialization API, which accepts a list of number IDs. Converting to a dataframe switches us to numpy dtypes, which are incompatible. Since there are other UI-driven ways to inspect cohorts, we'll leave conversion of this response to a dataframe as an exercise for the client.